### PR TITLE
Chunk spacing + smooth animations.

### DIFF
--- a/scripts/compression/raw_compression/wah.js
+++ b/scripts/compression/raw_compression/wah.js
@@ -51,6 +51,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -68,6 +69,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -82,6 +84,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -99,6 +102,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -113,6 +117,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -124,6 +129,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
+                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -136,6 +142,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                     runType: '',
                     startIndex: i,
                     compressed: wordAsString(compressed[index - 1], wordSize),
+                    uncompressed: chunkStr,
                 });
             }
             currentStartIndex = i + chunkSize;
@@ -150,6 +157,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                 runType: '1',
                 startIndex: currentStartIndex,
                 compressed: wordAsString(compressed[index - 1], wordSize),
+                uncompressed: string.slice(currentStartIndex),
             });
         }
     } else if (runZeros > 0) {//encode run of 0
@@ -160,6 +168,7 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                 runType: '0',
                 startIndex: currentStartIndex,
                 compressed: wordAsString(compressed[index - 1], wordSize),
+                uncompressed: string.slice(currentStartIndex),
             });
         }
     }

--- a/scripts/compression/raw_compression/wah.js
+++ b/scripts/compression/raw_compression/wah.js
@@ -51,7 +51,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -69,7 +68,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -84,7 +82,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -102,7 +99,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -117,7 +113,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '1',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runOnes = cast(0);
@@ -129,7 +124,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                         runType: '0',
                         startIndex: currentStartIndex,
                         compressed: wordAsString(compressed[index - 1], wordSize),
-                        uncompressed: string.slice(currentStartIndex, i + chunkSize),
                     });
                 }
                 runZeros = cast(0);
@@ -142,7 +136,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                     runType: '',
                     startIndex: i,
                     compressed: wordAsString(compressed[index - 1], wordSize),
-                    uncompressed: chunkStr,
                 });
             }
             currentStartIndex = i + chunkSize;
@@ -157,7 +150,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                 runType: '1',
                 startIndex: currentStartIndex,
                 compressed: wordAsString(compressed[index - 1], wordSize),
-                uncompressed: string.slice(currentStartIndex),
             });
         }
     } else if (runZeros > 0) {//encode run of 0
@@ -168,7 +160,6 @@ export const wahCompress = (string, wordSize, returnStates = false) => {
                 runType: '0',
                 startIndex: currentStartIndex,
                 compressed: wordAsString(compressed[index - 1], wordSize),
-                uncompressed: string.slice(currentStartIndex),
             });
         }
     }

--- a/scripts/wahVisualization/helperFunctions.js
+++ b/scripts/wahVisualization/helperFunctions.js
@@ -89,3 +89,8 @@ export const updateStartIndices = (states, litSize) => {
 
     return states;
 };
+
+
+export const easeInOutQuad = (t) => {
+    return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+};

--- a/scripts/wahVisualization/helperFunctions.js
+++ b/scripts/wahVisualization/helperFunctions.js
@@ -52,3 +52,40 @@ export const drawArrow = (ctx, fromX, fromY, toX, toY, headLength = 10) => {
     );
     ctx.stroke();
 }
+
+
+export const insertSpaceEveryNChars = (inputString, digit) => {
+    let result = '';
+    for (let i = 0; i < inputString.length; i++) {
+        result += inputString[i];
+        if ((i + 1) % digit === 0 && i !== inputString.length - 1) {
+            result += ' ';
+        }
+    }
+    return result;
+};
+
+
+export const updateStartIndices = (states, litSize) => {
+    let adjustedIndex = 0; // Tracks the adjusted start index including spaces
+
+    for (let i = 0; i < states.length; i++) {
+        const state = states[i];
+        const { runs, runType, startIndex } = state;
+
+        // Calculate the number of characters in the current state's uncompressed chunk
+        const uncompressedLength = runs === 0 ? litSize : litSize * runs;
+
+        // Calculate spaces added by `insertSpaceEveryNChars`
+        const spacesAdded = Math.floor(uncompressedLength / litSize); // Spaces per group of litSize digits
+
+        // Update the state's startIndex
+        state.startIndex = adjustedIndex;
+
+      
+        adjustedIndex += uncompressedLength + spacesAdded;
+        
+    }
+
+    return states;
+};


### PR DESCRIPTION
-  I added the spacing between chunks for the Wah animation. 
     - This is done by having a function insert spaces every chunk
     - Then adjusting the indices in the states
     - then adjusting a couple of calculations for `start_point`, `uncompressedStartIndex`, and ` new_start`
- Also added chunk spacing in the compressed output preview
    - To do this i just added a space to the compressed of the state when we push it the the compressed output.
     
- Smooth Transitioning
     - when you press next, it now smoothly goes though the micro steps between.
     - I applied a easeInOutQuad function. 


![image](https://github.com/user-attachments/assets/8681c9c1-c3af-433d-9038-9ff32ed0bb18)
